### PR TITLE
ignore errors on getOutline

### DIFF
--- a/src/Language/Haskell/BuildWrapper/API.hs
+++ b/src/Language/Haskell/BuildWrapper/API.hs
@@ -405,7 +405,9 @@ getOutline fp=do
                                 let ods=getHSEOutline ast
                                 let (es,is)=getHSEImportExport ast
                                 return (OutlineResult ods es is,bwns)
-                        Just (ParseFailed failLoc err)->return (OutlineResult [] [] [],BWNote BWError err (mkEmptySpan fp (srcLine failLoc) (srcColumn failLoc)) :bwns)
+                        Just (ParseFailed failLoc err)->return (OutlineResult [OutlineDef (T.pack " Outline not available") [Function] (mkFileSpan 0 0 0 0) [] Nothing Nothing] [] []
+                                                               ,{-BWNote BWError err (mkEmptySpan fp (srcLine failLoc) (srcColumn failLoc)) : -}
+                                                                bwns)
                         _ -> return (OutlineResult [] [] [],bwns)
  
 -- | get lexer token types for source file 


### PR DESCRIPTION
It turns out that haskell-src-exts is not working as expected. Modules with DoRec and TemplateHaskell cannot be parsed (and maybe other extensions cause problems as well.) The -XDoRec option is especially problematic, since there is no DoRec constructor in Language.Haskell.Exts.Extension.Extension. The method of stripping the -X will therefore not work.

But even putting the required extensions in language pragmas did not work. Whatever I tried, I could not get src-exts to parse this file:

```haskell
{-# LANGUAGE DoRec #-}
module Main where
parseProblem1 :: IO ()
parseProblem1 =
 do { rec { () <- return ()
          }
    ; return ()
    }
```

For problematic modules, the outline will be missing, but there will also be a parse error that is only briefly visible (until ghc has type checked). This causes flashing squigglies, and sometimes a stuck squiggly on a folder.

I propose that we simply ignore the output from src-exts, so at least the errors disappear.