### PR TITLE
Add additional entries to ".gitignore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 /.dist-buildwrapper
 /dist
 /.project
@@ -6,3 +5,10 @@
 /SourceGraph
 /.externalToolBuilders
 /cabal.sandbox.config
+/.cabal-sandbox/
+
+# From profiling:
+*.aux
+*.hp
+*.ps
+*.summary


### PR DESCRIPTION
- `.cabal-sandbox` directory.
- Artifacts generated by profiling, including postscript files.
- Fixed a couple line endings.
