### PR TITLE
Bump aeson upper version bounds

### DIFF
--- a/buildwrapper.cabal
+++ b/buildwrapper.cabal
@@ -37,7 +37,7 @@ library
                    haskell-src-exts >= 1.12 && <1.17,
                    cpphs,
                    old-time,
-                   aeson >=0.7 && <0.8,
+                   aeson >=0.7 && <0.9,
                    unordered-containers,
                    utf8-string,
                    bytestring,


### PR DESCRIPTION
Allow `BuildWrapper` to use the version 0.8 of `aeson` (which does not introduce major API changes).
