### PR TITLE
Added travis config and introduced lib-Werror flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: haskell
+
+ghc:
+  - 7.8
+  - 7.6
+  - 7.4
+
+before_install:
+  - ghc-pkg list
+  
+install:
+  - cabal install --dependencies-only --enable-tests
+  # add -flib-Werror if desired at a later point
+  - cabal configure --enable-tests
+  
+script:
+  - cabal build && cabal test
+  

--- a/buildwrapper.cabal
+++ b/buildwrapper.cabal
@@ -17,6 +17,10 @@ homepage:       https://github.com/JPMoresmau/BuildWrapper
 extra-source-files: README.md
                     CHANGELOG
 
+flag lib-Werror
+  default: False
+  manual: True
+
 library
   hs-source-dirs:  src
   build-depends:   
@@ -61,6 +65,8 @@ library
   if impl(ghc >= 7.6)
     build-depends: 
                     time
+  if flag(lib-Werror)
+    ghc-options: -Werror
 
 
 executable buildwrapper


### PR DESCRIPTION
Same game as JPMoresmau/ghc-pkg-lib#3. Before merging, please enable Travis CI. Fixes #50. Travis has build errors but I think these should be tackled in separate issues as I couldn't see any obvious (easy) work around like in ghc-pkg-lib. Note that I added the lib-Werror flag but I don't use it yet for the Travis CI builds as they there were indeed warnings. So this is a possible task for the future, but not as important now as fixing the real problems.